### PR TITLE
Add license file and license property in package.json

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2018 Andreas Lind <andreaslindpetersen@gmail.com>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the 'Software'), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/unexpectedjs/magicpen-media.git"
   },
   "main": "lib/magicPenMedia.js",
+  "license": "MIT",
   "author": "Andreas Lind <andreaslindpetersen@gmail.com>",
   "devDependencies": {
     "browserify": "^16.2.3",


### PR DESCRIPTION
@sunesimonsen asked for assistance adding a license field to this project on the gitter channel.

I don't have ownership of the npm package anyway, so I cannot publish a new package (I suppose that is necessary to solve the problem). So here is a PR.

I also think it's better to get explicit consent from you @papandreou when I'm licensing this module in your name ;-) Please merge if you don't disagree. 😎 🎅 